### PR TITLE
QA fixes for video player

### DIFF
--- a/src/components/CustomVideoPlayer.tsx
+++ b/src/components/CustomVideoPlayer.tsx
@@ -6,11 +6,11 @@ import Player from "@vimeo/player";
 import useBibleStore from "@/store/useBibleStore";
 
 const FilledPlayIcon = ({ size = 24, className = "" }) => (
-  <svg 
-    width={size} 
-    height={size} 
-    viewBox="0 0 24 24" 
-    fill="currentColor" 
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
     className={className}
   >
     <polygon points="5,3 19,12 5,21" />
@@ -18,11 +18,11 @@ const FilledPlayIcon = ({ size = 24, className = "" }) => (
 );
 
 const FilledPauseIcon = ({ size = 24, className = "" }) => (
-  <svg 
-    width={size} 
-    height={size} 
-    viewBox="0 0 24 24" 
-    fill="currentColor" 
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
     className={className}
   >
     <rect x="6" y="4" width="4" height="16" />
@@ -47,9 +47,7 @@ const CustomVideoPlayer = () => {
   const [duration, setDuration] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isEnded, setIsEnded] = useState(false);
-  const [lastAction, setLastAction] = useState<
-    "play" | "pause" | null
-  >(null);
+  const [lastAction, setLastAction] = useState<"play" | "pause" | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isPlayerReady, setIsPlayerReady] = useState(false);
 
@@ -494,7 +492,7 @@ const CustomVideoPlayer = () => {
       {showPlayBezel && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30">
           <div className="bg-black bg-opacity-50 rounded-full p-6">
-            {isEnded ? (
+            {isEnded && !(currentTime < duration) ? (
               <RefreshCw size={48} className="text-white" />
             ) : lastAction === "pause" ? (
               <FilledPauseIcon size={48} className="text-white" />
@@ -503,9 +501,9 @@ const CustomVideoPlayer = () => {
             )}
           </div>
         </div>
-      )}   
+      )}
       {/* Video Ended Overlay */}
-      {isEnded && (
+      {isEnded && !(currentTime < duration) && (
         <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
           <button
             onClick={replayVideo}
@@ -520,7 +518,7 @@ const CustomVideoPlayer = () => {
       <div
         className={`absolute inset-0 transition-opacity duration-300 ${
           showControls || isEnded ? "opacity-100" : "opacity-0"
-        } pointer-events-none z-20`}
+        } z-20`}
       >
         {/* Bottom Controls */}
         <div
@@ -578,17 +576,23 @@ const CustomVideoPlayer = () => {
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (isEnded) {
+                  if (isEnded && !(currentTime < duration)) {
                     replayVideo(e);
                   } else {
                     togglePlay();
                   }
                 }}
                 className="text-white hover:text-blue-400"
-                aria-label={isEnded ? "Replay" : isPlaying ? "Pause" : "Play"}
+                aria-label={
+                  isEnded && !(currentTime < duration)
+                    ? "Replay"
+                    : isPlaying
+                    ? "Pause"
+                    : "Play"
+                }
                 disabled={!isPlayerReady}
               >
-                {isEnded ? (
+                {isEnded && !(currentTime < duration) ? (
                   <RefreshCw size={24} />
                 ) : isPlaying ? (
                   <FilledPauseIcon size={24} />

--- a/src/components/CustomVideoPlayer.tsx
+++ b/src/components/CustomVideoPlayer.tsx
@@ -21,7 +21,7 @@ const CustomVideoPlayer = () => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [isEnded, setIsEnded] = useState(false);
   const [lastAction, setLastAction] = useState<
-    "play" | "pause" | "replay" | null
+    "play" | "pause" | null
   >(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isPlayerReady, setIsPlayerReady] = useState(false);
@@ -341,8 +341,6 @@ const CustomVideoPlayer = () => {
     setCurrentTime(0);
     setIsPlaying(true);
     setIsEnded(false);
-    setLastAction("replay");
-    // Show replay bezel effect
     setShowPlayBezel(true);
     setTimeout(() => setShowPlayBezel(false), 800);
   };
@@ -427,7 +425,7 @@ const CustomVideoPlayer = () => {
       onClick={togglePlay}
     >
       {!isPlayerReady && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black z-40">
+        <div className="absolute inset-0 flex items-center justify-center bg-black z-10">
           <div className="text-white text-lg">Loading video...</div>
         </div>
       )}
@@ -441,7 +439,7 @@ const CustomVideoPlayer = () => {
       {showPlayBezel && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30">
           <div className="bg-black bg-opacity-50 rounded-full p-6">
-            {lastAction === "replay" || isEnded ? (
+            {isEnded ? (
               <RefreshCw size={48} className="text-white" />
             ) : lastAction === "pause" ? (
               <Pause size={48} className="text-white" />

--- a/src/components/CustomVideoPlayer.tsx
+++ b/src/components/CustomVideoPlayer.tsx
@@ -1,9 +1,34 @@
 import { useState, useRef, useEffect } from "react";
-import { Play, Pause, RefreshCw, Maximize, Minimize } from "lucide-react";
+import { RefreshCw, Maximize, Minimize } from "lucide-react";
 import { bibleVerses, VerseData } from "../assets/data/bibleVersesSample";
 import { Options as VimeoPlayerOptions } from "@vimeo/player";
 import Player from "@vimeo/player";
 import useBibleStore from "@/store/useBibleStore";
+
+const FilledPlayIcon = ({ size = 24, className = "" }) => (
+  <svg 
+    width={size} 
+    height={size} 
+    viewBox="0 0 24 24" 
+    fill="currentColor" 
+    className={className}
+  >
+    <polygon points="5,3 19,12 5,21" />
+  </svg>
+);
+
+const FilledPauseIcon = ({ size = 24, className = "" }) => (
+  <svg 
+    width={size} 
+    height={size} 
+    viewBox="0 0 24 24" 
+    fill="currentColor" 
+    className={className}
+  >
+    <rect x="6" y="4" width="4" height="16" />
+    <rect x="14" y="4" width="4" height="16" />
+  </svg>
+);
 
 const CustomVideoPlayer = () => {
   const { currentVideoId } = useBibleStore();
@@ -442,9 +467,9 @@ const CustomVideoPlayer = () => {
             {isEnded ? (
               <RefreshCw size={48} className="text-white" />
             ) : lastAction === "pause" ? (
-              <Pause size={48} className="text-white" />
+              <FilledPauseIcon size={48} className="text-white" />
             ) : (
-              <Play size={48} className="text-white" />
+              <FilledPlayIcon size={48} className="text-white pl-1" />
             )}
           </div>
         </div>
@@ -479,12 +504,12 @@ const CustomVideoPlayer = () => {
           {/* Seekbar with sections */}
           <div
             ref={seekBarRef}
-            className="relative h-2 bg-gray-600 rounded-full mb-4 cursor-pointer"
+            className="relative h-1 bg-gray-600 rounded-full mb-4 cursor-pointer"
             onClick={handleSeekClick}
           >
             {/* Progress Bar */}
             <div
-              className="absolute top-0 left-0 h-2 bg-blue-500 rounded-full"
+              className="absolute top-0 left-0 h-1 bg-blue-500 rounded-full"
               style={{ width: `${progressPercent}%` }}
             ></div>
             {/* Verse markers */}
@@ -495,7 +520,7 @@ const CustomVideoPlayer = () => {
               return (
                 <div
                   key={verse.id}
-                  className={`absolute top-0 w-0.5 h-2 ${
+                  className={`absolute top-0 w-0.5 h-1 ${
                     isPassed ? "bg-yellow-400" : "bg-black"
                   }  cursor-pointer z-10 hover:w-1 transition-all duration-200`}
                   style={{
@@ -509,7 +534,7 @@ const CustomVideoPlayer = () => {
             })}
             {/* Current Time Indicator */}
             <div
-              className="absolute top-0 w-4 h-4 bg-white rounded-full cursor-grab z-20 -mt-1"
+              className="absolute top-0 w-4 h-4 bg-white rounded-full cursor-grab z-20 -mt-1.5"
               style={{
                 left: `${progressPercent}%`,
                 transform: "translateX(-50%)",
@@ -537,9 +562,9 @@ const CustomVideoPlayer = () => {
                 {isEnded ? (
                   <RefreshCw size={24} />
                 ) : isPlaying ? (
-                  <Pause size={24} />
+                  <FilledPauseIcon size={24} />
                 ) : (
-                  <Play size={24} />
+                  <FilledPlayIcon size={24} />
                 )}
               </button>
               {/* Timer */}


### PR DESCRIPTION
**QA Issues fixed**
- fixed showing **replay** bezel in the video screen when video is replayed from starting. Currently, it shows **play** icon bezel when replayed.
- added filled play and pause icons

**Additional fixes**
- restricted mouse move events to the video controls section only

**Issue not fixed**
Unable to track and implement idle/active mouse event for showing controls