### PR TITLE
added correct gif for Jude book

### DIFF
--- a/web-app/src/assets/data/book_codes.json
+++ b/web-app/src/assets/data/book_codes.json
@@ -387,7 +387,7 @@
     "book": "Jude",
     "bookId": 65,
     "bookCode": "jud",
-    "filename" : "Judge.gif"
+    "filename" : "Jude.gif"
   },
   {
     "book": "Revelation",


### PR DESCRIPTION
Updated the book GIF for Jude. Previously it used the same GIF as Judges; now it uses Jude.gif.
Previously using this 
<img width="496" height="184" alt="Screenshot from 2026-02-10 14-39-13" src="https://github.com/user-attachments/assets/d303ca7a-cd73-4093-91de-0038e79bbc01" />
<img width="506" height="141" alt="Screenshot from 2026-02-10 14-38-54" src="https://github.com/user-attachments/assets/21f2fc81-bc6e-40bf-9da0-8731e8b8cf85" />
Now changed it to 
<img width="480" height="303" alt="image" src="https://github.com/user-attachments/assets/9d4c5570-323d-4f12-9936-60a33a4b0c59" />


