### PR TITLE
adding top component in all pages

### DIFF
--- a/web-app/src/components/Menu.tsx
+++ b/web-app/src/components/Menu.tsx
@@ -8,35 +8,49 @@ export default function Menu({ onClose }: { onClose: () => void }) {
     navigate(path);
     onClose();
   };
-   const showBible = location.pathname !== "/HomePage";
-   const showDictionary = location.pathname !== "/dictionary";
-   const showProjects = location.pathname !== "/projects";
- 
+  const isBible = location.pathname === "/HomePage";
+  const isDictionary = location.pathname === "/dictionary";
+  const isProjects = location.pathname === "/projects";
+
   return (
-    <div className="absolute w-40 left-0 bg-white border border-gray-200    ">
-      {showBible && (
-      <div className="px-2 py-2 cursor-pointer hover:bg-gray-200 transition">
-        <p onClick={() => go("/HomePage")} className="cursor-pointer ">
-          Bible
-        </p>
+    <div className="absolute w-40 left-0 bg-white border border-gray-200">
+  
+      {/* Bible */}
+      <div
+        onClick={() => !isBible && go("/HomePage")}
+        className={`px-2 py-2 transition ${
+          isBible
+            ? "text-gray-400 cursor-not-allowed bg-gray-50"
+            : "cursor-pointer hover:bg-gray-200"
+        }`}
+      >
+        Bible
       </div>
-      )}
-      {showDictionary && (
-      <p
-        onClick={() => go("/dictionary")}
-        className="px-2 py-2 cursor-pointer hover:bg-gray-200 transition "
+  
+      {/* Dictionary */}
+      <div
+        onClick={() => !isDictionary && go("/dictionary")}
+        className={`px-2 py-2 transition ${
+          isDictionary
+            ? "text-gray-400 cursor-not-allowed bg-gray-50"
+            : "cursor-pointer hover:bg-gray-200"
+        }`}
       >
         Dictionary
-      </p>
-      )}
-      {showProjects && (
-      <p
-        onClick={() => go("/projects")}
-        className="px-2 py-2 cursor-pointer hover:bg-gray-200 transition "
+      </div>
+  
+      {/* Projects */}
+      <div
+        onClick={() => !isProjects && go("/projects")}
+        className={`px-2 py-2 transition ${
+          isProjects
+            ? "text-gray-400 cursor-not-allowed bg-gray-50"
+            : "cursor-pointer hover:bg-gray-200"
+        }`}
       >
         The Bible Project
-      </p>
-      )}
+      </div>
+  
     </div>
   );
-}
+}  

--- a/web-app/src/components/Menu.tsx
+++ b/web-app/src/components/Menu.tsx
@@ -1,30 +1,42 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate , useLocation} from "react-router-dom";
 
 export default function Menu({ onClose }: { onClose: () => void }) {
   const navigate = useNavigate();
+  const location = useLocation();
+
   const go = (path: string) => {
     navigate(path);
     onClose();
   };
+   const showBible = location.pathname !== "/HomePage";
+   const showDictionary = location.pathname !== "/dictionary";
+   const showProjects = location.pathname !== "/projects";
+ 
   return (
     <div className="absolute w-40 left-0 bg-white border border-gray-200    ">
+      {showBible && (
       <div className="px-2 py-2 cursor-pointer hover:bg-gray-200 transition">
         <p onClick={() => go("/HomePage")} className="cursor-pointer ">
           Bible
         </p>
       </div>
+      )}
+      {showDictionary && (
       <p
         onClick={() => go("/dictionary")}
         className="px-2 py-2 cursor-pointer hover:bg-gray-200 transition "
       >
         Dictionary
       </p>
+      )}
+      {showProjects && (
       <p
         onClick={() => go("/projects")}
         className="px-2 py-2 cursor-pointer hover:bg-gray-200 transition "
       >
         The Bible Project
       </p>
+      )}
     </div>
   );
 }

--- a/web-app/src/components/Menu.tsx
+++ b/web-app/src/components/Menu.tsx
@@ -20,7 +20,7 @@ export default function Menu({ onClose }: { onClose: () => void }) {
         onClick={() => !isBible && go("/HomePage")}
         className={`px-2 py-2 transition ${
           isBible
-            ? "text-gray-400 cursor-not-allowed bg-gray-50"
+  ? "text-gray-400 cursor-default bg-gray-50 pointer-events-none"
             : "cursor-pointer hover:bg-gray-200"
         }`}
       >
@@ -32,7 +32,7 @@ export default function Menu({ onClose }: { onClose: () => void }) {
         onClick={() => !isDictionary && go("/dictionary")}
         className={`px-2 py-2 transition ${
           isDictionary
-            ? "text-gray-400 cursor-not-allowed bg-gray-50"
+  ? "text-gray-400 cursor-default bg-gray-50 pointer-events-none"
             : "cursor-pointer hover:bg-gray-200"
         }`}
       >
@@ -44,7 +44,7 @@ export default function Menu({ onClose }: { onClose: () => void }) {
         onClick={() => !isProjects && go("/projects")}
         className={`px-2 py-2 transition ${
           isProjects
-            ? "text-gray-400 cursor-not-allowed bg-gray-50"
+          ? "text-gray-400 cursor-default bg-gray-50 pointer-events-none"
             : "cursor-pointer hover:bg-gray-200"
         }`}
       >

--- a/web-app/src/components/Navbar.tsx
+++ b/web-app/src/components/Navbar.tsx
@@ -5,7 +5,7 @@ import Settings from "./Settings";
 import SearchboxBCV from "./SearchboxBCV";
 import { MenuIcon } from "lucide-react";
 import Menu from "./Menu";
-
+import { useLocation } from "react-router-dom";
 import Logo from "../assets/images/ISLV_Logo.svg";
 import { Link } from "react-router-dom";
 
@@ -19,13 +19,13 @@ const Navbar: React.FC<NavbarProps> = ({ items }) => {
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLDivElement>(null);
-
+  const location = useLocation();
+  const isLandingPage = location.pathname === "/";
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
 
       if (target.closest('[role="dialog"]')) {
-        // setIsSettingsOpen(false)
         return;
       }
       if (
@@ -68,7 +68,6 @@ const Navbar: React.FC<NavbarProps> = ({ items }) => {
 
   return (
     <nav className="relative w-full bg-[#000063] min-h-14 flex  items-center">
-      {/* <div className="relative w-full mx-auto flex flex-1 gap-8 justify-between"> */}
       <div className="w-full  flex items-center relative">
         <div className="ml-4 cursor-pointer text-white" ref={menuButtonRef}>
           <MenuIcon
@@ -99,10 +98,11 @@ const Navbar: React.FC<NavbarProps> = ({ items }) => {
           ))}
         </Link>
       </div>
-      {/* <div className="flex items-center justify-between gap-8 flex-1"> */}
-      <div className="absolute  left-1/2 transform -translate-x-1/2">
-        <SearchboxBCV />
-      </div>
+      {!isLandingPage && (
+  <div className="absolute  left-1/2 transform -translate-x-1/2">
+    <SearchboxBCV />
+  </div>
+)}
       <div
         className=" h-12 w-12 bg-white rounded-full flex-shrink-0"
         ref={settingsRef}

--- a/web-app/src/components/SearchboxBCV.tsx
+++ b/web-app/src/components/SearchboxBCV.tsx
@@ -8,7 +8,6 @@ import SearchboxTooltip from "./SearchboxToolTip";
 import { useLocation } from "react-router-dom";
 
 interface SearchboxBCVProps {
-  placeholder?: string;
   className?: string;
 }
 
@@ -54,7 +53,6 @@ const verseUtils = {
 };
 
 function SearchboxBCV({
-  placeholder = "Search ",
   className = "",
 }: SearchboxBCVProps) {
   const [inputValue, setInputValue] = useState("");
@@ -69,6 +67,17 @@ function SearchboxBCV({
 
   const location = useLocation();
   const isHomepage = location.pathname === "/HomePage";
+
+  const getPlaceholder = () => {
+    if (location.pathname === "/HomePage") {
+      return "Search Bible Reference";
+    } else if (location.pathname === "/dictionary") {
+      return "Search Dictionary";
+    } else if (location.pathname === "/projects") {
+      return "Search The Bible Projects";
+    }
+    return "Search Bible Reference";
+  };
 
   const errorMsg =
     "Invalid search format\nPlease try the following:\nJohn 3:16 or psa 1";
@@ -541,7 +550,7 @@ function SearchboxBCV({
             onKeyDown={handleKeyPress}
             onFocus={handleFocus}
             onBlur={handleBlur}
-            placeholder={placeholder}
+            placeholder={getPlaceholder()}
             className="flex-1 outline-none bg-transparent min-w-0 overflow-hidden text-ellipsis"
             disabled={isSearching}
           />
@@ -581,7 +590,7 @@ function SearchboxBCV({
           </div>
         )}
       </div>
-      {isHomepage &&
+{isHomepage &&
         !errorMessage &&
         !showSuggestions &&
         (isHovered || isFocused) && <SearchboxTooltip />}


### PR DESCRIPTION
Issue no - #261
Landing page top bar with no search bar - 
<img width="1848" height="92" alt="image" src="https://github.com/user-attachments/assets/1700d3e3-c916-41cd-b69f-7ae553281187" />
Main Bible page top bar - 
<img width="1848" height="92" alt="image" src="https://github.com/user-attachments/assets/471bc142-05bb-41dc-a9e7-632c1756f57b" />
Dictionary page top bar - 
<img width="1848" height="92" alt="image" src="https://github.com/user-attachments/assets/caf87871-103f-4521-a4e5-f2b2311de6fe" />
The Bible projects top bar - 
<img width="1848" height="92" alt="image" src="https://github.com/user-attachments/assets/caa01b29-fde1-4f24-bc2b-632b3e43bfb5" />

Also the menu will change according to the page - 
- for Landing page all 3 options are visible 
- for bible page , 2 options ( dictionary and The bible projects )
- for dictionary page - 2 options ( Bible and The Bible projects )
- for The bible projects page - 2 options ( Bible and Dictionary)